### PR TITLE
For uses where you dont need the color picker

### DIFF
--- a/src/Color.php
+++ b/src/Color.php
@@ -64,4 +64,9 @@ class Color extends Field
     {
         return $this->pickerType('swatches');
     }
+    
+    public function plain()
+    {
+        return $this->pickerType('plain');
+    }
 }


### PR DESCRIPTION
If you want to show the color field that show the hex color but do not need a picker. For example when copying a brand color and I just want to see that the hex looks correct.

It works now with `Color::make('Primary Color')->pickerType('plain')` because there is no picker called plain, but an even more elegant solution would be if you could set `Color::make('Primary Color')->pickerType(null)` or for short: `Color::make('Primary Color')->plain()`